### PR TITLE
Plugins and Monolithic support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "volttron-lib-bacnet-driver"
-version = "2.0.0rc0"
+version = "2.0.0rc2"
 description = "BACnet driver supported and maintained by the Volttron team."
 authors = ["VOLTTRON Team <volttron@pnnl.gov>"]
 license = "Apache License 2.0"
@@ -24,9 +24,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-volttron-lib-base-driver = ">=2.0.0rc0"
-bacpypes3 = ">=0.0.102"
-protocol-proxy-bacnet = ">=2.0.0rc0"
+volttron-lib-base-driver = ">=2.0.0rc3"
+protocol-proxy-bacnet = ">=2.0.0rc3"
 
 [tool.poetry.group.dev.dependencies]
 pytest-sugar = "^0.9.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["poetry-core>=1.2.2"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "volttron-lib-bacnet-driver"
 version = "2.0.0rc0"
 description = "BACnet driver supported and maintained by the Volttron team."
-authors = ["Mark Bonicillo <volttron@pnnl.gov>"]
+authors = ["VOLTTRON Team <volttron@pnnl.gov>"]
 license = "Apache License 2.0"
 readme = "README.md"
 repository = "https://github.com/eclipse-volttron/volttron-lib-bacnet-driver"

--- a/src/volttron/driver/interfaces/bacnet/bacnet.py
+++ b/src/volttron/driver/interfaces/bacnet/bacnet.py
@@ -396,6 +396,6 @@ class BACnet(BaseInterface):
             self.driver_agent.publish_push(result)
 
     @classmethod
-    def unique_remote_id(cls, config_name: str, config: BacnetRemoteConfig) -> tuple:
-        # TODO: This should probably incorporate information which currently belongs to the BACnet Proxy Agent.
-        return config.target_address, config.device_id
+    def unique_remote_id(cls, config_name: str, config: RemoteConfig) -> tuple:
+        bacnet_config = cls.INTERFACE_CONFIG_CLASS(**config.model_dump())
+        return bacnet_config.target_address, bacnet_config.device_id

--- a/src/volttron/driver/interfaces/bacnet/bacnet.py
+++ b/src/volttron/driver/interfaces/bacnet/bacnet.py
@@ -35,7 +35,6 @@ from typing import Annotated, Any, cast
 from protocol_proxy.ipc import ProtocolProxyMessage, ProtocolProxyPeer, callback
 from protocol_proxy.manager.gevent import GeventProtocolProxyManager
 
-from volttron.client.vip.agent import errors
 from volttron.driver.base.config import empty_str_is, PointConfig, RemoteConfig
 from volttron.driver.base.driver_exceptions import DriverConfigError
 from volttron.driver.base.interfaces import BaseInterface, BaseRegister
@@ -231,10 +230,8 @@ class BACnet(BaseInterface):
                          ))
             pinged = True
         # TODO: What exceptions might we really encounter, now, through PPM?
-        except errors.Unreachable:
-            _log.warning("Unable to reach BACnet proxy.")
-        except errors.VIPError:
-            _log.warning("Error trying to ping device.")
+        except Exception as e:
+            _log.warning(f"Error trying to ping device: {e}")
 
         self.scheduled_ping = None
         # Schedule retry.


### PR DESCRIPTION
* Removed dependency on volttron-core (will now work without changes on monolithic).
* Changed handling of configuration classes when getting unique_remote_ids to facilitate use with plugins.